### PR TITLE
feat: Add comprehensive F5 load balancer support and verification

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "dev::main",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}",
+      "args": ["-i", "test-f5.conf"]
+    }
+  ]
+}

--- a/main.go
+++ b/main.go
@@ -85,16 +85,16 @@ func verify(servers []parser.ServerInfo, vservers []parser.VServerInfo, serviceG
 	return success
 }
 
-// verifyWithMappingsAndSource performs enhanced verification by comparing Citrix commands with generated mappings
-// Supports both file input and stdin input
+// verifyWithMappingsAndSource performs enhanced verification by comparing L7 load balancer commands with generated mappings
+// Supports both file input and stdin input and works with both Citrix and F5 configurations
 func verifyWithMappingsAndSource(inputSource, mappingFolder string, useStdin bool) bool {
 	if useStdin {
-		fmt.Printf("Enhanced verification: comparing Citrix commands from stdin with mappings in '%s'\n", mappingFolder)
+		fmt.Printf("Enhanced verification: comparing L7 load balancer commands from stdin with mappings in '%s'\n", mappingFolder)
 	} else {
-		fmt.Printf("Enhanced verification: comparing Citrix commands in '%s' with mappings in '%s'\n", inputSource, mappingFolder)
+		fmt.Printf("Enhanced verification: comparing L7 load balancer commands in '%s' with mappings in '%s'\n", inputSource, mappingFolder)
 	}
 
-	// Parse the Citrix settings
+	// Parse the L7 load balancer settings (auto-detects Citrix or F5 format)
 	var servers []parser.ServerInfo
 	var vservers []parser.VServerInfo
 	var serviceGroupDefs []parser.ServiceGroupDef
@@ -109,7 +109,7 @@ func verifyWithMappingsAndSource(inputSource, mappingFolder string, useStdin boo
 	}
 
 	if err != nil {
-		fmt.Printf("Error parsing Citrix settings: %v\n", err)
+		fmt.Printf("Error parsing L7 load balancer settings: %v\n", err)
 		return false
 	}
 
@@ -159,7 +159,7 @@ func verifyWithMappingsAndSource(inputSource, mappingFolder string, useStdin boo
 		success = verifyMappings(expectedMappingConfig, actualMappingConfig) && success
 	}
 
-	// Verify that all Citrix services have corresponding Traefik services
+	// Verify that all L7 services have corresponding Traefik services
 	fmt.Println("\n=== Verifying Service Coverage ===")
 	success = verifyServiceCoverage(serviceGroups, expectedTraefikConfig) && success
 
@@ -168,7 +168,7 @@ func verifyWithMappingsAndSource(inputSource, mappingFolder string, useStdin boo
 	success = verifyVServerCoverage(vservers, expectedMappingConfig) && success
 
 	if success {
-		fmt.Println("\n✅ Enhanced verification passed - all Citrix commands correctly mapped!")
+		fmt.Println("\n✅ Enhanced verification passed - all L7 load balancer commands correctly mapped!")
 	} else {
 		fmt.Println("\n❌ Enhanced verification failed - discrepancies found!")
 	}
@@ -271,7 +271,7 @@ func verifyMappings(expected, actual parser.MappingConfig) bool {
 	return success
 }
 
-// verifyServiceCoverage ensures all Citrix service groups have corresponding Traefik services
+// verifyServiceCoverage ensures all L7 service groups have corresponding Traefik services
 func verifyServiceCoverage(serviceGroups []parser.ServiceGroup, traefikConfig parser.TraefikConfig) bool {
 	success := true
 
@@ -284,17 +284,17 @@ func verifyServiceCoverage(serviceGroups []parser.ServiceGroup, traefikConfig pa
 	// Check if each service group has a corresponding Traefik service
 	for serviceName := range serviceGroupNames {
 		if _, exists := traefikConfig.HTTP.Services[serviceName]; !exists {
-			fmt.Printf("❌ Citrix service group '%s' not found in Traefik services\n", serviceName)
+			fmt.Printf("❌ Service group '%s' not found in Traefik services\n", serviceName)
 			success = false
 		} else {
-			fmt.Printf("✅ Citrix service group '%s' mapped to Traefik service\n", serviceName)
+			fmt.Printf("✅ Service group '%s' mapped to Traefik service\n", serviceName)
 		}
 	}
 
 	return success
 }
 
-// verifyVServerCoverage ensures all Citrix virtual servers have corresponding mappings
+// verifyVServerCoverage ensures all L7 virtual servers have corresponding mappings
 func verifyVServerCoverage(vservers []parser.VServerInfo, mappingConfig parser.MappingConfig) bool {
 	success := true
 
@@ -312,10 +312,10 @@ func verifyVServerCoverage(vservers []parser.VServerInfo, mappingConfig parser.M
 	// Check if each virtual server has a corresponding mapping
 	for _, vserver := range vservers {
 		if !mappingsByVServer[vserver.Name] {
-			fmt.Printf("❌ Citrix virtual server '%s' (%s:%s) not found in mappings\n", vserver.Name, vserver.IP, vserver.Port)
+			fmt.Printf("❌ Virtual server '%s' (%s:%s) not found in mappings\n", vserver.Name, vserver.IP, vserver.Port)
 			success = false
 		} else {
-			fmt.Printf("✅ Citrix virtual server '%s' (%s:%s) mapped correctly\n", vserver.Name, vserver.IP, vserver.Port)
+			fmt.Printf("✅ Virtual server '%s' (%s:%s) mapped correctly\n", vserver.Name, vserver.IP, vserver.Port)
 		}
 	}
 
@@ -326,7 +326,7 @@ func main() {
 	// Define command line flags
 	verifyMode := flag.Bool("y", false, "Verify mode - perform verification checks on the L7 settings file and mapping folder")
 	outputMode := flag.Bool("o", false, "Output mode - print mappings to stdout instead of writing to files")
-	inputFile := flag.String("i", "", "Input Citrix settings file (use '-' or omit for stdin)")
+	inputFile := flag.String("i", "", "Input L7 load balancer settings file (Citrix or F5 format - use '-' or omit for stdin)")
 	mappingFolder := flag.String("m", "", "Mapping folder containing traefik-services.yaml and mapping.yaml (required for verification mode)")
 	flag.Parse()
 

--- a/pkg/parser/f5_parser.go
+++ b/pkg/parser/f5_parser.go
@@ -128,7 +128,7 @@ func parseF5PoolsSimple(content string) []F5PoolSimple {
 			}
 
 			// Pool member
-			if memberMatch := regexp.MustCompile(`(/Common/\d+[\.\d]+):(\d+)\s*\{`).FindStringSubmatch(trimmed); memberMatch != nil {
+			if memberMatch := regexp.MustCompile(`(/Common/\d{1,3}(?:\.\d{1,3}){3}):(\d+)\s*\{`).FindStringSubmatch(trimmed); memberMatch != nil {
 				port, _ := strconv.Atoi(memberMatch[2])
 				currentPool.Members = append(currentPool.Members, F5PoolMemberSimple{
 					Address: strings.TrimPrefix(memberMatch[1], "/Common/"),
@@ -233,48 +233,13 @@ func convertF5ToTraefikFormat(nodes []F5NodeSimple, pools []F5PoolSimple, virtua
 		ipToServerName[node.Address] = cleanName
 	}
 
-	// Convert F5 pools to ServiceGroupDef and ServiceGroup
+	// Create a map of pools for quick lookup
+	poolMap := make(map[string]F5PoolSimple)
 	for _, pool := range pools {
-		cleanPoolName := strings.TrimPrefix(pool.Name, "/Common/")
-
-		// Create service group definition
-		serviceGroupDefs = append(serviceGroupDefs, ServiceGroupDef{
-			Name:     cleanPoolName,
-			Protocol: "HTTP", // Default to HTTP for F5 pools
-			Comment:  pool.Description,
-		})
-
-		// Create service group bindings for each pool member
-		for _, member := range pool.Members {
-			// Determine the server name to use
-			var serverName string
-			if existingName, exists := ipToServerName[member.Address]; exists {
-				// Use the existing node name
-				serverName = existingName
-			} else {
-				// Ensure we have a server entry for this IP
-				if !serverMap[member.Address] && member.Address != "" {
-					servers = append(servers, ServerInfo{
-						Name:    member.Address, // Use IP as name if no node definition exists
-						IP:      member.Address,
-						Comment: "Auto-generated from F5 pool member",
-					})
-					serverMap[member.Address] = true
-					ipToServerName[member.Address] = member.Address
-				}
-				serverName = member.Address
-			}
-
-			serviceGroups = append(serviceGroups, ServiceGroup{
-				Name:       cleanPoolName,
-				ServerName: serverName, // Use consistent server name
-				Port:       strconv.Itoa(member.Port),
-				Comment:    pool.Description,
-			})
-		}
+		poolMap[pool.Name] = pool
 	}
 
-	// Convert F5 virtual servers to VServerInfo and VServerBinding
+	// Convert F5 virtual servers to VServerInfo and create service groups using virtual server names
 	for _, virtual := range virtuals {
 		cleanVirtualName := strings.TrimPrefix(virtual.Name, "/Common/")
 
@@ -289,13 +254,58 @@ func convertF5ToTraefikFormat(nodes []F5NodeSimple, pools []F5PoolSimple, virtua
 					Port:     parts[1],
 				})
 
-				// Create vserver binding if pool is specified
+				// If this virtual server has a pool, create service group using virtual server name
 				if virtual.Pool != "" {
-					cleanPoolName := strings.TrimPrefix(virtual.Pool, "/Common/")
-					vserverBindings = append(vserverBindings, VServerBinding{
-						VServerName: cleanVirtualName,
-						ServiceName: cleanPoolName,
-						Comment:     virtual.Description,
+					if pool, exists := poolMap[virtual.Pool]; exists {
+						// Create service group definition using virtual server name
+						serviceGroupDefs = append(serviceGroupDefs, ServiceGroupDef{
+							Name:     cleanVirtualName, // Use virtual server name instead of pool name
+							Protocol: "HTTP",
+							Comment:  pool.Description,
+						})
+
+						// Create service group bindings for each pool member
+						for _, member := range pool.Members {
+							// Determine the server name to use
+							var serverName string
+							if existingName, exists := ipToServerName[member.Address]; exists {
+								// Use the existing node name
+								serverName = existingName
+							} else {
+								// Ensure we have a server entry for this IP
+								if !serverMap[member.Address] && member.Address != "" {
+									servers = append(servers, ServerInfo{
+										Name:    member.Address, // Use IP as name if no node definition exists
+										IP:      member.Address,
+										Comment: "Auto-generated from F5 pool member",
+									})
+									serverMap[member.Address] = true
+									ipToServerName[member.Address] = member.Address
+								}
+								serverName = member.Address
+							}
+
+							serviceGroups = append(serviceGroups, ServiceGroup{
+								Name:       cleanVirtualName, // Use virtual server name
+								ServerName: serverName,
+								Port:       strconv.Itoa(member.Port),
+								Comment:    pool.Description,
+							})
+						}
+
+						// Create vserver binding using virtual server name
+						vserverBindings = append(vserverBindings, VServerBinding{
+							VServerName: cleanVirtualName,
+							ServiceName: cleanVirtualName, // Service group also uses virtual server name
+							Comment:     virtual.Description,
+						})
+					}
+				} else {
+					// Virtual server without pool - create empty service group
+					serviceGroupDefs = append(serviceGroupDefs, ServiceGroupDef{
+						Name:     cleanVirtualName,
+						Protocol: "HTTP",
+						Comment:  "F5 Virtual Server without pool",
 					})
 				}
 			}


### PR DESCRIPTION
- Implement F5 BIG-IP configuration parser (f5_parser.go)
  - Parse ltm node, pool, and virtual server configurations
  - Convert F5 structures to unified internal format
  - Fix regex patterns for IP address matching in pool members
  - Resolve server name mapping inconsistencies

- Add intelligent auto-detection system (auto_detect.go)
  - Automatically detect Citrix vs F5 configuration formats
  - Weighted scoring system with format-specific indicators
  - Seamless parser selection based on content analysis

- Enhance verification system for universal L7 support (main.go)
  - All verification functions now work with both Citrix and F5
  - Update messaging to be format-agnostic (L7 load balancer)
  - Maintain full verification coverage for both formats

- Update command line interface
  - Help text mentions both Citrix and F5 format support
  - Error messages provide clear feedback for both types

- Verified functionality with comprehensive testing
  - F5 configuration parsing and mapping generation
  - Enhanced verification passes for F5 configs
  - Backward compatibility maintained for Citrix configs

This enables seamless migration from F5 BIG-IP load balancers to Traefik with the same verification capabilities as Citrix NetScaler configurations.